### PR TITLE
Be docker-friendly: Create /dev/net/tun if it does not exist

### DIFF
--- a/protonvpn_cli/cli.py
+++ b/protonvpn_cli/cli.py
@@ -97,6 +97,7 @@ def cli():
     elif args.get("c") or args.get("connect"):
         check_root()
         check_init()
+        create_dev_tun()
 
         # Wait until a connection to the ProtonVPN API can be made
         # As this is mainly for automatically connecting on boot, it only

--- a/protonvpn_cli/cli.py
+++ b/protonvpn_cli/cli.py
@@ -59,7 +59,7 @@ from .logger import logger
 from .utils import (
     check_root, change_file_owner, pull_server_data,
     check_init, set_config_value, get_config_value,
-    is_valid_ip, wait_for_network
+    is_valid_ip, wait_for_network, create_dev_tun
 )
 # Constants
 from .constants import (

--- a/protonvpn_cli/utils.py
+++ b/protonvpn_cli/utils.py
@@ -9,6 +9,7 @@ import re
 import random
 import ipaddress
 import math
+import stat
 # External Libraries
 import requests
 from jinja2 import Environment, FileSystemLoader
@@ -471,6 +472,14 @@ def check_init():
         logger.debug("Initialized Profile not found")
         sys.exit(1)
 
+
+def create_dev_tun():
+    if os.path.exists('/dev/net/tun'):
+        return
+    os.mkdir("/dev/net/")
+    os.mknod("/dev/net/tun",
+             mode=0o0755 | stat.S_IFCHR,
+             device=os.makedev(10, 200))
 
 def is_valid_ip(ipaddr):
     valid_ip_re = re.compile(

--- a/protonvpn_cli/utils.py
+++ b/protonvpn_cli/utils.py
@@ -481,6 +481,7 @@ def create_dev_tun():
              mode=0o0755 | stat.S_IFCHR,
              device=os.makedev(10, 200))
 
+
 def is_valid_ip(ipaddr):
     valid_ip_re = re.compile(
         r'^(25[0-5]|2[0-4][0-9]|[0-1]?[0-9][0-9]?)\.'


### PR DESCRIPTION
I understand I should have discussed this PR before submitting it, but I am perfectly fine if you do not accept it, also I think it would have taken more time to discuss than to fix it :)

#### Problem
If you try to use `protonvpn` in docker, it fails. It fails because OpenVPN cannot start:
```
Fri Jan  8 18:51:31 2021 ROUTE_GATEWAY 172.17.0.1/255.255.0.0 IFACE=eth0 HWADDR=02:42:ac:11:00:02
Fri Jan  8 18:51:31 2021 ERROR: Cannot open TUN/TAP dev /dev/net/tun: No such file or directory (errno=2)
Fri Jan  8 18:51:31 2021 Exiting due to fatal error
```

#### Solution

So, it [looks like](https://www.google.com/search?q=openvpn+%2Fdev%2Fnet%2Ftun+no+such+device) we need to create the device explicitly (if it does not exist).