### PR TITLE
Exclude multicast DNS from the killswitch in mode 2

### DIFF
--- a/protonvpn_cli/connection.py
+++ b/protonvpn_cli/connection.py
@@ -851,6 +851,9 @@ def manage_killswitch(mode, proto=None, port=None):
             exclude_lan_commands = [
                 "iptables -A OUTPUT -o {0} -d {1} -j ACCEPT".format(default_nic, local_network), # noqa
                 "iptables -A INPUT -i {0} -s {1} -j ACCEPT".format(default_nic, local_network), # noqa
+                # multicast DNS
+                "iptables -A OUTPUT -p udp -o {0} -d 224.0.0.251/32 --dport 5353 -j ACCEPT ".format(default_nic), # noqa
+                "iptables -A INPUT -p udp -i {0} -s 224.0.0.251/32 --sport 5353 -j ACCEPT".format(default_nic), # noqa
             ]
 
             for lan_command in exclude_lan_commands:


### PR DESCRIPTION
Allow access to multicast DNS addresses if the killswitch is enabled, so that we can still use mDNS hostnames for devices on the local network. Without this, mDNS doesn't seem to work at all, even if the killswitch isn't active.

Resolves #247, and replaces #248 which got into a strange conflicted state after being open for so long.